### PR TITLE
refactor(maven): parent relations and use miranum versions from maven central

### DIFF
--- a/customer-onboarding-showcase/customer-onboarding-frontend/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-frontend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/customer-onboarding-showcase/customer-onboarding-mail/customer-onboarding-mail-c7/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-mail/customer-onboarding-mail-c7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-mail</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>customer-onboarding-mail-core</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->

--- a/customer-onboarding-showcase/customer-onboarding-mail/customer-onboarding-mail-core/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-mail/customer-onboarding-mail-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-mail</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>

--- a/customer-onboarding-showcase/customer-onboarding-mail/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-mail/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <modules>

--- a/customer-onboarding-showcase/customer-onboarding-risk-evaluation/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-risk-evaluation/pom.xml
@@ -15,6 +15,6 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 </project>

--- a/customer-onboarding-showcase/customer-onboarding-risk-evaluation/risk-evaluation-c7/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-risk-evaluation/risk-evaluation-c7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-risk-evaluation</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>risk-evaluation-core</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->

--- a/customer-onboarding-showcase/customer-onboarding-risk-evaluation/risk-evaluation-core/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-risk-evaluation/risk-evaluation-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-risk-evaluation</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>

--- a/customer-onboarding-showcase/customer-onboarding-starter/customer-onboarding-starter-c7/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-starter/customer-onboarding-starter-c7/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>customer-onboarding-starter-core</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->

--- a/customer-onboarding-showcase/customer-onboarding-starter/customer-onboarding-starter-core/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-starter/customer-onboarding-starter-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>customer-onboarding-starter-core</artifactId>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-api</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>${miranum.version}</version>
         </dependency>
     </dependencies>
 

--- a/customer-onboarding-showcase/customer-onboarding-starter/pom.xml
+++ b/customer-onboarding-showcase/customer-onboarding-starter/pom.xml
@@ -16,6 +16,6 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>customer-onboarding-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 </project>

--- a/customer-onboarding-showcase/pom.xml
+++ b/customer-onboarding-showcase/pom.xml
@@ -19,7 +19,7 @@
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
-        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
+        <miranum.version>0.1.0</miranum.version>
     </properties>
 
     <modules>

--- a/customer-onboarding-showcase/pom.xml
+++ b/customer-onboarding-showcase/pom.xml
@@ -5,16 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>customer-onboarding-showcase</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
-    <name>customer-onboarding-showcase</name>
+    <version>1.0.0</version>
+    <name>Customer Onboarding Showcase</name>
     <packaging>pom</packaging>
-
-    <parent>
-        <groupId>io.miragon.miranum.consulting</groupId>
-        <artifactId>miranum-consulting</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
-    </parent>
-
 
     <properties>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pizza-order-showcase/kitchen/kitchen-c7/pom.xml
+++ b/pizza-order-showcase/kitchen/kitchen-c7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>kitchen</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,19 +22,19 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>kitchen-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>message-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/kitchen/kitchen-c8/pom.xml
+++ b/pizza-order-showcase/kitchen/kitchen-c8/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>kitchen</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,19 +22,19 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>kitchen-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>message-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/kitchen/kitchen-core/pom.xml
+++ b/pizza-order-showcase/kitchen/kitchen-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>kitchen</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pizza-order-showcase/kitchen/pom.xml
+++ b/pizza-order-showcase/kitchen/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>pizza-order-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <modules>

--- a/pizza-order-showcase/notification/notification-c7/pom.xml
+++ b/pizza-order-showcase/notification/notification-c7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>notification</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,14 +22,14 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>notification-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/notification/notification-c8/pom.xml
+++ b/pizza-order-showcase/notification/notification-c8/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>notification</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,14 +22,14 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>notification-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/notification/notification-core/pom.xml
+++ b/pizza-order-showcase/notification/notification-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>notification</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -21,12 +21,12 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>mail-core</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pizza-order-showcase/notification/pom.xml
+++ b/pizza-order-showcase/notification/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>pizza-order-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <modules>

--- a/pizza-order-showcase/pizza-order-frontend/pom.xml
+++ b/pizza-order-showcase/pizza-order-frontend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.miragon.miranum.consulting</groupId>
 		<artifactId>pizza-order-showcase</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/pizza-order-showcase/pom.xml
+++ b/pizza-order-showcase/pom.xml
@@ -19,7 +19,7 @@
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
-        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
+        <miranum.version>0.1.0</miranum.version>
     </properties>
 
     <modules>

--- a/pizza-order-showcase/pom.xml
+++ b/pizza-order-showcase/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>pizza-order-showcase</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
-    <name>pizza-order-showcase</name>
+    <version>1.0.0</version>
+    <name>Pizza Order Showcase</name>
     <packaging>pom</packaging>
 
     <properties>
@@ -19,6 +19,7 @@
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
+        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
     </properties>
 
     <modules>

--- a/pizza-order-showcase/waiter/pom.xml
+++ b/pizza-order-showcase/waiter/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>pizza-order-showcase</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <modules>

--- a/pizza-order-showcase/waiter/waiter-c7/pom.xml
+++ b/pizza-order-showcase/waiter/waiter-c7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>waiter</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,25 +22,25 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>waiter-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>message-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/waiter/waiter-c8/pom.xml
+++ b/pizza-order-showcase/waiter/waiter-c8/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>waiter</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,24 +22,24 @@
         <dependency>
             <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>waiter-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>message-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/pizza-order-showcase/waiter/waiter-core/pom.xml
+++ b/pizza-order-showcase/waiter/waiter-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>waiter</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>miranum-consulting</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>Miranum Consulting</name>
     <packaging>pom</packaging>
     <description>Miranum-Consulting</description>

--- a/process-example/pom.xml
+++ b/process-example/pom.xml
@@ -26,7 +26,7 @@
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
-        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
+        <miranum.version>0.1.0</miranum.version>
     </properties>
 
     <dependencyManagement>

--- a/process-example/pom.xml
+++ b/process-example/pom.xml
@@ -3,16 +3,12 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>process-example</artifactId>
-    <name>process-example</name>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
-    <description>miranum process examples</description>
-
-    <parent>
-        <groupId>io.miragon.miranum.consulting</groupId>
-        <artifactId>miranum-consulting</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
-    </parent>
+    <name>Process Example</name>
+    <description>Miranum process examples</description>
 
     <modules>
         <module>process-example-camunda-7</module>
@@ -30,6 +26,7 @@
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
+        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
     </properties>
 
     <dependencyManagement>

--- a/process-example/process-example-camunda-7/pom.xml
+++ b/process-example/process-example-camunda-7/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>process-example</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,20 +22,20 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-example-core</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-adapter-c7</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/process-example/process-example-camunda-7/pom.xml
+++ b/process-example/process-example-camunda-7/pom.xml
@@ -20,9 +20,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.miragon.miranum</groupId>
+            <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>process-example-core</artifactId>
-            <version>${miranum.version}</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->

--- a/process-example/process-example-camunda-8/pom.xml
+++ b/process-example/process-example-camunda-8/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>process-example</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -22,20 +22,20 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-example-core</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Miranum-->
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-adapter-c8</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
 
         <!--Camunda-->

--- a/process-example/process-example-camunda-8/pom.xml
+++ b/process-example/process-example-camunda-8/pom.xml
@@ -20,9 +20,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.miragon.miranum</groupId>
+            <groupId>io.miragon.miranum.consulting</groupId>
             <artifactId>process-example-core</artifactId>
-            <version>${miranum.version}</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--Miranum-->

--- a/process-example/process-example-core/pom.xml
+++ b/process-example/process-example-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.miragon.miranum.consulting</groupId>
         <artifactId>process-example</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <dependencies>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>worker-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>process-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
     </dependencies>
 

--- a/restaurant-showcase/pom.xml
+++ b/restaurant-showcase/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
         <cloudStreamKafka.version>4.0.2</cloudStreamKafka.version>
-        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
+        <miranum.version>0.1.0</miranum.version>
     </properties>
 
     <modules>

--- a/restaurant-showcase/pom.xml
+++ b/restaurant-showcase/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>restaurant-showcase</artifactId>
-    <name>restaurant-showcase</name>
+    <name>Restaurant Showcase</name>
     <version>1.0.0</version>
     <packaging>pom</packaging>
 

--- a/schema-client-example/pom.xml
+++ b/schema-client-example/pom.xml
@@ -2,16 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <groupId>io.miragon.miranum.consulting</groupId>
     <artifactId>schema-client-example</artifactId>
-    <name>schema-client-example</name>
+    <version>1.0.0</version>
+    <name>Schema Client Example</name>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
-
-    <parent>
-        <groupId>io.miragon.miranum.consulting</groupId>
-        <artifactId>miranum-consulting</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
-    </parent>
 
     <properties>
         <maven.compiler.target>17</maven.compiler.target>
@@ -21,6 +17,7 @@
         <spring.boot.version>2.7.8</spring.boot.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
+        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
     </properties>
 
     <dependencyManagement>
@@ -48,7 +45,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>json-api</artifactId>
-            <version>${project.version}</version>
+            <version>${miranum.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/schema-client-example/pom.xml
+++ b/schema-client-example/pom.xml
@@ -17,7 +17,7 @@
         <spring.boot.version>2.7.8</spring.boot.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.26</lombok.version>
-        <miranum.version>0.1.0-SNAPSHOT</miranum.version>
+        <miranum.version>0.1.0</miranum.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**
Closes #13 


**Description**
Having miranum-consulting as parent restricts us having naming two modules the same way in two different showcase projects.


**Checklist**
* [x] Code is easy to understand
* [ ] No obvious errors or bugs
* [ ] CI/CD Pipelines did run successfully
* [ ] Tests were implemented
* [ ] Documentation was created
